### PR TITLE
Fix resolveValue with DateTimeImmutable value

### DIFF
--- a/src/Query/Interpolator.php
+++ b/src/Query/Interpolator.php
@@ -123,7 +123,7 @@ final class Interpolator
                     return "'" . addcslashes((string)$parameter, "'") . "'";
                 }
 
-                if ($parameter instanceof \DateTime) {
+                if ($parameter instanceof \DateTimeInterface) {
                     //Let's process dates different way
                     return "'" . $parameter->format(\DateTime::ISO8601) . "'";
                 }

--- a/tests/Database/InterpolatorTest.php
+++ b/tests/Database/InterpolatorTest.php
@@ -89,4 +89,21 @@ class InterpolatorTest extends TestCase
             $interpolated
         );
     }
+
+    public function testDateInterpolationWithDateTimeImmutable()
+    {
+        $query = 'SELECT * FROM table WHERE name = :name AND registered > :registered';
+
+        $parameters = [
+            ':name'       => new Parameter('Anton'),
+            ':registered' => new Parameter($date = new \DateTimeImmutable('now')),
+        ];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            'SELECT * FROM table WHERE name = \'Anton\' AND registered > \'' . $date->format(\DateTime::ISO8601) . '\'',
+            $interpolated
+        );
+    }
 }


### PR DESCRIPTION
Logging of query parameters didn't work with DateTimeImmutable. Consider the following quick & dirty script: 

```php
<?php

use Psr\Log\AbstractLogger;
use Spiral\Database\Config\DatabaseConfig;
use Spiral\Database\DatabaseManager;
use Spiral\Database\Driver\SQLite\SQLiteDriver;

require 'vendor/autoload.php';

$config = [
    'debug' => true,
    'default'     => 'default',
    'databases'   => [
        'default' => [
            'connection' => 'sqlite'
        ]
    ],
    'connections' => [
        'sqlite'    => [
            'driver' => SQLiteDriver::class,
            'options' => [
                'connection'   => 'sqlite::memory:',
                'username'   => 'sqlite',
                'password'   => ''
            ]
        ],
    ]
];

$dbal = new DatabaseManager(new DatabaseConfig($config));
$db = $dbal->database();
/** @var SQLiteDriver $driver */
$driver = $db->getDriver();
$driver->setLogger(new class extends AbstractLogger {

    public function log($level, $message, array $context = [])
    {
        dump($message);
    }

});
$driver->setProfiling();
$db->query('SELECT :date', [':date' => new \DateTimeImmutable()])->fetchAll();
```

Without these changes this would output the following:

```
string(19) SELECT [UNRESOLVED]
```

Versus the expected:

```
string(33) SELECT '2019-10-06T15:42:51+0200'
```
