### PR TITLE
Support for indexes sort order

### DIFF
--- a/src/Driver/MySQL/Schema/MySQLIndex.php
+++ b/src/Driver/MySQL/Schema/MySQLIndex.php
@@ -28,6 +28,9 @@ class MySQLIndex extends AbstractIndex
         foreach ($schema as $definition) {
             $index->type = $definition['Non_unique'] ? self::NORMAL : self::UNIQUE;
             $index->columns[] = $definition['Column_name'];
+            if ($definition['Collation'] === 'D') {
+                $index->sort[$definition['Column_name']] = 'DESC';
+            }
         }
 
         return $index;

--- a/src/Driver/MySQL/Schema/MySQLTable.php
+++ b/src/Driver/MySQL/Schema/MySQLTable.php
@@ -35,6 +35,13 @@ class MySQLTable extends AbstractTable
     private $engine = self::ENGINE_INNODB;
 
     /**
+     * MySQL version.
+     *
+     * @var string
+     */
+    private $version;
+
+    /**
      * Change table engine. Such operation will be applied only at moment of table creation.
      *
      * @param string $engine
@@ -77,6 +84,17 @@ class MySQLTable extends AbstractTable
                 $state->getName()
             ]
         )->fetch()['Engine'];
+    }
+
+    protected function isIndexColumnSortingSupported(): bool
+    {
+        if (!$this->version) {
+            $this->version = $this->driver->query('SELECT VERSION() AS version')
+                ->fetch()['version'];
+        }
+
+        $isMariaDB = strpos($this->version, 'MariaDB') !== false;
+        return !$isMariaDB;
     }
 
     /**

--- a/src/Driver/Postgres/Schema/PostgresIndex.php
+++ b/src/Driver/Postgres/Schema/PostgresIndex.php
@@ -30,7 +30,13 @@ class PostgresIndex extends AbstractIndex
 
             foreach ($columns as $column) {
                 //Postgres adds quotes to all columns with uppercase letters
-                $index->columns[] = trim($column, ' "\'');
+                $column = trim($column, ' "\'');
+                [$column, $order] = AbstractIndex::parseColumn($column);
+
+                $index->columns[] = $column;
+                if ($order) {
+                    $index->sort[$column] = $order;
+                }
             }
         }
 

--- a/src/Driver/SQLServer/Schema/SQLServerIndex.php
+++ b/src/Driver/SQLServer/Schema/SQLServerIndex.php
@@ -28,6 +28,9 @@ class SQLServerIndex extends AbstractIndex
 
         foreach ($schema as $indexColumn) {
             $index->columns[] = $indexColumn['columnName'];
+            if (intval($indexColumn['isDescendingKey']) === 1) {
+                $index->sort[$indexColumn['columnName']] = 'DESC';
+            }
         }
 
         return $index;

--- a/src/Driver/SQLServer/Schema/SQLServerTable.php
+++ b/src/Driver/SQLServer/Schema/SQLServerTable.php
@@ -66,7 +66,8 @@ class SQLServerTable extends AbstractTable
      */
     protected function fetchIndexes(): array
     {
-        $query = 'SELECT [indexes].[name] AS [indexName], [cl].[name] AS [columnName], '
+        $query = 'SELECT [indexes].[name] AS [indexName], '
+            . '[cl].[name] AS [columnName], [columns].[is_descending_key] AS [isDescendingKey], '
             . "[is_primary_key] AS [isPrimary], [is_unique] AS [isUnique]\n"
             . "FROM [sys].[indexes] AS [indexes]\n"
             . "INNER JOIN [sys].[index_columns] as [columns]\n"

--- a/src/Driver/SQLite/Schema/SQLiteTable.php
+++ b/src/Driver/SQLite/Schema/SQLiteTable.php
@@ -68,7 +68,7 @@ class SQLiteTable extends AbstractTable
                 $this->getName(),
                 $schema,
                 $this->driver->query(
-                    "PRAGMA INDEX_INFO({$this->driver->quote($schema['name'])})"
+                    "PRAGMA INDEX_XINFO({$this->driver->quote($schema['name'])})"
                 )->fetchAll()
             );
 

--- a/src/IndexInterface.php
+++ b/src/IndexInterface.php
@@ -36,4 +36,11 @@ interface IndexInterface
      * @return array
      */
     public function getColumns(): array;
+
+    /**
+     * Columns mapping to sorting order
+     *
+     * @return array
+     */
+    public function getSort(): array;
 }

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -141,7 +141,7 @@ final class Comparator implements ComparatorInterface
     {
         $difference = [];
         foreach ($this->current->getIndexes() as $name => $index) {
-            if (!$this->initial->hasIndex($index->getColumns())) {
+            if (!$this->initial->hasIndex($index->getColumnsWithSort())) {
                 $difference[] = $index;
             }
         }
@@ -156,7 +156,7 @@ final class Comparator implements ComparatorInterface
     {
         $difference = [];
         foreach ($this->initial->getIndexes() as $name => $index) {
-            if (!$this->current->hasIndex($index->getColumns())) {
+            if (!$this->current->hasIndex($index->getColumnsWithSort())) {
                 $difference[] = $index;
             }
         }
@@ -174,12 +174,12 @@ final class Comparator implements ComparatorInterface
         $difference = [];
 
         foreach ($this->current->getIndexes() as $name => $index) {
-            if (!$this->initial->hasIndex($index->getColumns())) {
+            if (!$this->initial->hasIndex($index->getColumnsWithSort())) {
                 //Added into schema
                 continue;
             }
 
-            $initial = $this->initial->findIndex($index->getColumns());
+            $initial = $this->initial->findIndex($index->getColumnsWithSort());
             if (!$index->compare($initial)) {
                 $difference[] = [$index, $initial];
             }

--- a/src/Schema/State.php
+++ b/src/Schema/State.php
@@ -261,7 +261,7 @@ final class State
     public function findIndex(array $columns): ?AbstractIndex
     {
         foreach ($this->indexes as $index) {
-            if ($index->getColumns() === $columns) {
+            if ($index->getColumnsWithSort() === $columns) {
                 return $index;
             }
         }

--- a/tests/Database/BaseTest.php
+++ b/tests/Database/BaseTest.php
@@ -218,20 +218,20 @@ abstract class BaseTest extends TestCase
 
         foreach ($source->getIndexes() as $index) {
             $this->assertTrue(
-                $target->hasIndex($index->getColumns()),
+                $target->hasIndex($index->getColumnsWithSort()),
                 "Index {$index->getName()} has been removed"
             );
 
-            $this->compareIndexes($index, $target->findIndex($index->getColumns()));
+            $this->compareIndexes($index, $target->findIndex($index->getColumnsWithSort()));
         }
 
         foreach ($target->getIndexes() as $index) {
             $this->assertTrue(
-                $source->hasIndex($index->getColumns()),
+                $source->hasIndex($index->getColumnsWithSort()),
                 "Index {$index->getName()} has been removed"
             );
 
-            $this->compareIndexes($index, $source->findIndex($index->getColumns()));
+            $this->compareIndexes($index, $source->findIndex($index->getColumnsWithSort()));
         }
 
         // FK

--- a/tests/Database/Driver/MySQL/IndexesTest.php
+++ b/tests/Database/Driver/MySQL/IndexesTest.php
@@ -14,4 +14,13 @@ namespace Spiral\Database\Tests\Driver\MySQL;
 class IndexesTest extends \Spiral\Database\Tests\IndexesTest
 {
     public const DRIVER = 'mysql';
+
+    public function testCreateWithComplexExpressionIndex(): void
+    {
+        if (getenv('DB') === 'mariadb') {
+            $this->expectExceptionMessageRegExp('/column sorting is not supported$/');
+        }
+
+        parent::testCreateWithComplexExpressionIndex();
+    }
 }

--- a/tests/Database/IndexesTest.php
+++ b/tests/Database/IndexesTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Spiral\Database\Tests;
 
+use Spiral\Database\Database;
 use Spiral\Database\Driver\Handler;
 use Spiral\Database\Schema\AbstractColumn;
 use Spiral\Database\Schema\AbstractTable;
@@ -77,6 +78,21 @@ abstract class IndexesTest extends BaseTest
         $schema->integer('value');
         $schema->string('subset', 2);
         $schema->index(['value', 'subset']);
+
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+    }
+
+    public function testCreateWithComplexExpressionIndex(): void
+    {
+        $schema = $this->schema('table');
+        $this->assertFalse($schema->exists());
+
+        $schema->primary('id');
+        $schema->integer('value');
+        $schema->string('subset', 2);
+        $schema->index(['subset', 'value DESC']);
 
         $schema->save(Handler::DO_ALL);
 


### PR DESCRIPTION
This implements the ability to specify column order in indexes like so:

```
$schema->index(['key1', 'key2 DESC']);
```

Currently, the behavior for `key2 ASC` is undefined as it's the default, so if someone changes an index adding ASC, it might force drop and re-create the index for no good reason.

For MySQL version < 8.0 this will break as it [ignores](https://dev.mysql.com/doc/refman/5.7/en/create-index.html) `key-type` order (and by breaks, I mean it might also drop and re-create the index).

Closes #18.