### PR TITLE
Fix SQLite `syncTable` regression, add drop ordered index test

### DIFF
--- a/src/Driver/SQLite/SQLiteHandler.php
+++ b/src/Driver/SQLite/SQLiteHandler.php
@@ -182,7 +182,7 @@ class SQLiteHandler extends Handler
 
         //We don't need any indexes in temporary table
         foreach ($temporary->getIndexes() as $index) {
-            $temporary->dropIndex($index->getColumns());
+            $temporary->dropIndex($index->getColumnsWithSort());
         }
 
         $this->createTable($temporary);

--- a/tests/Database/Driver/MySQL/IndexesTest.php
+++ b/tests/Database/Driver/MySQL/IndexesTest.php
@@ -15,12 +15,21 @@ class IndexesTest extends \Spiral\Database\Tests\IndexesTest
 {
     public const DRIVER = 'mysql';
 
-    public function testCreateWithComplexExpressionIndex(): void
+    public function testCreateOrderedIndex(): void
     {
         if (getenv('DB') === 'mariadb') {
             $this->expectExceptionMessageRegExp('/column sorting is not supported$/');
         }
 
-        parent::testCreateWithComplexExpressionIndex();
+        parent::testCreateOrderedIndex();
+    }
+
+    public function testDropOrderedIndex(): void
+    {
+        if (getenv('DB') === 'mariadb') {
+            $this->expectExceptionMessageRegExp('/column sorting is not supported$/');
+        }
+
+        parent::testDropOrderedIndex();
     }
 }

--- a/tests/Database/IndexesTest.php
+++ b/tests/Database/IndexesTest.php
@@ -84,7 +84,7 @@ abstract class IndexesTest extends BaseTest
         $this->assertSameAsInDB($schema);
     }
 
-    public function testCreateWithComplexExpressionIndex(): void
+    public function testCreateOrderedIndex(): void
     {
         $schema = $this->schema('table');
         $this->assertFalse($schema->exists());
@@ -258,6 +258,21 @@ abstract class IndexesTest extends BaseTest
         $this->assertTrue($schema->exists());
 
         $schema->dropIndex(['email', 'status']);
+
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+    }
+
+    public function testDropOrderedIndex(): void
+    {
+        $schema = $this->sampleSchemaWithIndexes('table');
+
+        $schema->index(['id', 'balance DESC']);
+        $schema->save(Handler::DO_ALL);
+        $this->assertTrue($schema->exists());
+
+        $schema->dropIndex(['id', 'balance DESC']);
 
         $schema->save(Handler::DO_ALL);
 


### PR DESCRIPTION
An omission on my part was preventing `syncTable` to properly work with ordered indexes in SQLite. Also added a test case for dropping ordered index.