### PR TITLE
Migrate CI to Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,155 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    name: Check coding standards
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Restore Composer Cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install Dependencies
+        run: composer install --no-interaction --prefer-dist
+      - name: Check CS
+        run: vendor/bin/spiral-cs check src tests
+  test:
+    needs: lint
+    name: Test PHP ${{ matrix.php-versions }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['7.2', '7.3', '7.4']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup DB services
+        run: |
+          cd tests
+          docker-compose up -d
+          cd ..
+      - name: Setup PHP ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: pcov
+          tools: pecl
+          extensions: mbstring, pdo, pdo_sqlsrv
+      - name: Install MS SQL Server deps
+        run: |
+          bash ./tests/install-sqlsrv.sh
+          sudo sed -i.bak '/^extension="pdo_sqlsrv.so"/d' /etc/php/${{ matrix.php-versions }}/cli/php.ini
+          sudo bash -c 'printf "; priority=30\nextension=pdo_sqlsrv.so\n" > /etc/php/${{ matrix.php-versions }}/mods-available/pdo_sqlsrv.ini'
+          sudo phpenmod -s cli -v ${{ matrix.php-versions }} pdo_sqlsrv
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Restore Composer Cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install Dependencies
+        run: composer install --no-interaction --prefer-dist
+      - name: Execute Tests
+        run: |
+          vendor/bin/phpunit --coverage-clover=coverage.xml
+#      - name: Upload coverage to Codecov
+#        uses: codecov/codecov-action@v1
+#        with:
+#          token: ${{ secrets.CODECOV_TOKEN }}
+#          file: ./coverage.xml
+  test_postgres:
+    needs: lint
+    name: Test PostgreSQL ${{ matrix.configs.postgres-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        configs: [
+          {php-version: 7.2, postgres-version: 9.6},
+          {php-version: 7.3, postgres-version: 10},
+          {php-version: 7.3, postgres-version: 11}
+        ]
+    services:
+      postgres:
+        image: postgres:${{ matrix.configs.postgres-version }}
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: spiral
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP ${{ matrix.configs.php-version }}
+        run: sudo update-alternatives --set php /usr/bin/php${{ matrix.configs.php-version }}
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Restore Composer Cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install Dependencies
+        run: composer install --no-interaction --prefer-dist
+      - name: Execute Tests
+        env:
+          DB: postgres
+          POSTGRES: ${{ matrix.configs.postgres-version }}
+        run: |
+          vendor/bin/phpunit tests/Database/Driver/Postgres
+  test_mariadb:
+    needs: lint
+    name: Test MariaDB ${{ matrix.configs.mariadb-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        configs: [
+#          {php-version: 7.2, mariadb-version: 10.2},
+          {php-version: 7.3, mariadb-version: 10.4}
+        ]
+    services:
+      mariadb:
+        image: mariadb:${{ matrix.configs.mariadb-version }}
+        ports:
+          - 23306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: spiral
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP ${{ matrix.configs.php-version }}
+        run: sudo update-alternatives --set php /usr/bin/php${{ matrix.configs.php-version }}
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Restore Composer Cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install Dependencies
+        run: composer install --no-interaction --prefer-dist
+      - name: Execute Tests
+        env:
+          DB: mariadb
+          MARIADB: ${{ matrix.configs.mariadb-version }}
+        run: |
+          vendor/bin/phpunit tests/Database/Driver/MySQL

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Spiral DBAL
 ========
 [![Latest Stable Version](https://poser.pugx.org/spiral/database/v/stable)](https://packagist.org/packages/spiral/database) 
-[![Build Status](https://travis-ci.org/spiral/database.svg?branch=master)](https://travis-ci.org/spiral/database)
+[![Build Status](https://github.com/spiral/database/workflows/build/badge.svg)](https://github.com/spiral/database/actions)
 [![Codecov](https://codecov.io/gh/spiral/database/branch/master/graph/badge.svg)](https://codecov.io/gh/spiral/database/)
 
 Secure, multiple SQL dialects (MySQL, PostgreSQL, SQLite, SQLServer), schema introspection, schema declaration, smart identifier wrappers, database partitions, query builders, nested queries.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "spiral/pagination": "^2.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "~7.0",
+    "phpunit/phpunit": "~8.0",
     "mockery/mockery": "^1.1",
     "spiral/dumper": "^1.0",
     "spiral/code-style": "^1.0",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -76,22 +76,7 @@ if (!empty(getenv('DB'))) {
                     },
                     'conn'   => 'pgsql:host=127.0.0.1;port=5432;dbname=spiral',
                     'user'   => 'postgres',
-                    'pass'   => ''
-                ],
-            ];
-            break;
-
-        case 'mysql':
-            Database\Tests\BaseTest::$config = [
-                'debug' => false,
-                'mysql' => [
-                    'driver' => Database\Driver\MySQL\MySQLDriver::class,
-                    'check'  => static function () {
-                        return true;
-                    },
-                    'conn'   => 'mysql:host=127.0.0.1:3306;dbname=spiral',
-                    'user'   => 'root',
-                    'pass'   => 'root'
+                    'pass'   => 'postgres'
                 ],
             ];
             break;
@@ -104,9 +89,9 @@ if (!empty(getenv('DB'))) {
                     'check'  => static function () {
                         return true;
                     },
-                    'conn'   => 'mysql:host=127.0.0.1:3306;dbname=spiral',
+                    'conn'   => 'mysql:host=127.0.0.1:23306;dbname=spiral',
                     'user'   => 'root',
-                    'pass'   => ''
+                    'pass'   => 'root'
                 ],
             ];
             break;

--- a/tests/install-sqlsrv.sh
+++ b/tests/install-sqlsrv.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 set -ex
-sudo apt update
-sudo apt install unixodbc-dev
-pecl install pdo_sqlsrv-5.6.0
 curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql.list
-sudo apt update
+curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+sudo apt-get update
 
-ACCEPT_EULA=Y sudo apt-get install -qy msodbcsql17 mssql-tools unixodbc libssl1.0.0
+sudo ACCEPT_EULA=Y apt-get install -qy msodbcsql17 mssql-tools


### PR DESCRIPTION
This PR brings the following changes:

1. [x] Switch to PCOV for code coverage (presumably, it is much faster that XDebug)
2. [x] Upgrade to PHPUnit 8, mostly because PCOV is supported out of the box on v8
3. [x] Migrate away from Travis CI to Github Actions (full support of all existing feature matrices)
4. [ ] Upload tests coverage to codecov - this will be turned on once `secrets.CODECOV_TOKEN` is added in repository settings.