### PR TITLE
Method for creating context for logging

### DIFF
--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -491,9 +491,7 @@ abstract class Driver implements DriverInterface, LoggerAwareInterface
         } finally {
             if ($this->logger !== null) {
                 $queryString = Interpolator::interpolate($query, $parameters);
-                $context = [
-                    'elapsed' => microtime(true) - $queryStart
-                ];
+                $context = $this->createLoggerContext($queryStart, $statement ?? null);
 
                 if (isset($e)) {
                     $this->logger->error($queryString, $context);
@@ -692,5 +690,25 @@ abstract class Driver implements DriverInterface, LoggerAwareInterface
     protected function getDSN(): string
     {
         return $this->options['connection'] ?? $this->options['dsn'] ?? $this->options['addr'];
+    }
+
+    /**
+     * Creating a context for logging
+     *
+     * @param float             $queryStart Query start time
+     * @param PDOStatement|null $statement  Statement
+     *
+     * @return array
+     */
+    protected function createLoggerContext(float $queryStart, ?PDOStatement $statement): array
+    {
+        $context = [
+            'elapsed' => microtime(true) - $queryStart,
+        ];
+        if ($statement) {
+            $context['rowCount'] = $statement->rowCount();
+        }
+
+        return $context;
     }
 }

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -491,7 +491,7 @@ abstract class Driver implements DriverInterface, LoggerAwareInterface
         } finally {
             if ($this->logger !== null) {
                 $queryString = Interpolator::interpolate($query, $parameters);
-                $context = $this->createLoggerContext($queryStart, $statement ?? null);
+                $context = $this->defineLoggerContext($queryStart, $statement ?? null);
 
                 if (isset($e)) {
                     $this->logger->error($queryString, $context);
@@ -700,12 +700,12 @@ abstract class Driver implements DriverInterface, LoggerAwareInterface
      *
      * @return array
      */
-    protected function createLoggerContext(float $queryStart, ?PDOStatement $statement): array
+    protected function defineLoggerContext(float $queryStart, ?PDOStatement $statement): array
     {
         $context = [
             'elapsed' => microtime(true) - $queryStart,
         ];
-        if ($statement) {
+        if ($statement !== null) {
             $context['rowCount'] = $statement->rowCount();
         }
 


### PR DESCRIPTION
Added a method to create a logging context.
This is necessary in order to be able to name not only elapsed, but also data such as the number of lines in the insert update.
Added functionality since I did not find any clues for the ability to transfer additional parameters to the logger