### PR TITLE
fix: commit transaction

### DIFF
--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -406,6 +406,10 @@ abstract class Driver implements DriverInterface, LoggerAwareInterface
             }
 
             try {
+                if (!$this->getPDO()->inTransaction()) {
+                    return true;
+                }
+
                 return $this->getPDO()->commit();
             } catch (Throwable $e) {
                 throw $this->mapException($e, 'COMMIT TRANSACTION');


### PR DESCRIPTION
When trying to commit a transaction that has already been committed an
exception is throw. Now we are testing to see we are inside a
transaction before committing it to prevent an exception being thrown.

Reference to [the comment on #50](https://github.com/spiral/database/issues/50#issuecomment-758276221) this has changed a bit. Now the test for a transaction has been moved earlier and is returning. This was continuing on to release the save point 0 that never gets created.

Ref: #50