### PR TITLE
Provide a default prefix to `compile` in `sqlStatement`

### DIFF
--- a/src/Query/ActiveQuery.php
+++ b/src/Query/ActiveQuery.php
@@ -103,7 +103,9 @@ abstract class ActiveQuery implements QueryInterface
             throw new BuilderException('Unable to build query without associated driver');
         }
 
-        return $this->driver->getQueryCompiler()->compile(
+        $compiler = $this->driver->getQueryCompiler();
+
+        return $compiler->compile(
             $parameters ?? new QueryParameters(),
             $this->prefix ?? '',
             $this

--- a/src/Query/ActiveQuery.php
+++ b/src/Query/ActiveQuery.php
@@ -105,7 +105,7 @@ abstract class ActiveQuery implements QueryInterface
 
         return $this->driver->getQueryCompiler()->compile(
             $parameters ?? new QueryParameters(),
-            $this->prefix ?? "",
+            $this->prefix ?? '',
             $this
         );
     }

--- a/src/Query/ActiveQuery.php
+++ b/src/Query/ActiveQuery.php
@@ -105,7 +105,7 @@ abstract class ActiveQuery implements QueryInterface
 
         return $this->driver->getQueryCompiler()->compile(
             $parameters ?? new QueryParameters(),
-            $this->prefix,
+            $this->prefix ?? "",
             $this
         );
     }


### PR DESCRIPTION
When creating an ActiveQuery without a prefix (which is possible since the prefix property is nullable), the `sqlStatement` method fails since it passes the prefix property to `$this->driver->getQueryCompiler()->compile` which expects a string. I suggest to fallback to an empty string when the prefix property is null.