### PR TITLE
Integrate mysql datetime precision.

### DIFF
--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -34,7 +34,7 @@ abstract class Driver implements DriverInterface, LoggerAwareInterface
     use LoggerAwareTrait;
 
     // DateTime format to be used to perform automatic conversion of DateTime objects.
-    protected const DATETIME = 'Y-m-d H:i:s';
+    protected const DATETIME = 'Y-m-d H:i:s.u';
 
     // Driver specific PDO options
     protected const DEFAULT_PDO_OPTIONS = [
@@ -605,13 +605,7 @@ abstract class Driver implements DriverInterface, LoggerAwareInterface
      */
     protected function formatDatetime(DateTimeInterface $value): string
     {
-        try {
-            $datetime = new DateTimeImmutable('now', $this->getTimezone());
-        } catch (Throwable $e) {
-            throw new DriverException($e->getMessage(), $e->getCode(), $e);
-        }
-
-        return $datetime->setTimestamp($value->getTimestamp())->format(static::DATETIME);
+        return $value->setTimezone($this->getTimezone())->format(static::DATETIME);
     }
 
     /**

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -605,7 +605,7 @@ abstract class Driver implements DriverInterface, LoggerAwareInterface
      */
     protected function formatDatetime(DateTimeInterface $value): string
     {
-        return $value->setTimezone($this->getTimezone())->format(static::DATETIME);
+        return (clone $value)->setTimezone($this->getTimezone())->format(static::DATETIME);
     }
 
     /**

--- a/src/Driver/MySQL/Schema/MySQLColumn.php
+++ b/src/Driver/MySQL/Schema/MySQLColumn.php
@@ -13,6 +13,7 @@ namespace Spiral\Database\Driver\MySQL\Schema;
 
 use Spiral\Database\Driver\DriverInterface;
 use Spiral\Database\Exception\DefaultValueException;
+use Spiral\Database\Exception\SchemaException;
 use Spiral\Database\Injection\Fragment;
 use Spiral\Database\Injection\FragmentInterface;
 use Spiral\Database\Schema\AbstractColumn;
@@ -264,5 +265,26 @@ class MySQLColumn extends AbstractColumn
         }
 
         return parent::formatDatetime($type, $value);
+    }
+
+    /**
+     * Set column type as datetime with specific size (precision).
+     *
+     * @param int $size
+     * @return self|$this
+     *
+     * @throws SchemaException
+     */
+    public function datetime(int $size = 0): AbstractColumn
+    {
+        $this->type('datetime');
+
+        if ($size > 6) {
+            throw new SchemaException('Invalid size (precision) value; must be between 0 and 6.');
+        }
+
+        $this->size = (int)$size;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Greetings,

This incorporates mysql datetime precision.

Need help cleaning this up for other database drivers if necessary.

Not sure why formatDatetime was doing what it was doing instead of just setting the timezone on the datetime instance, the code snip was required to get the datetime precision to carry over, so please advise as necessary.

Thank you.