### PR TITLE
Change minimum SQL server to version 11 from 12

### DIFF
--- a/src/Driver/SQLServer/SQLServerDriver.php
+++ b/src/Driver/SQLServer/SQLServerDriver.php
@@ -43,8 +43,8 @@ class SQLServerDriver extends Driver
             QueryBuilder::defaultBuilder()
         );
 
-        if ((int)$this->getPDO()->getAttribute(\PDO::ATTR_SERVER_VERSION) < 12) {
-            throw new DriverException('SQLServer driver supports only 12+ version of SQLServer');
+        if ((int)$this->getPDO()->getAttribute(\PDO::ATTR_SERVER_VERSION) < 11) {
+            throw new DriverException('SQLServer driver supports only 11+ version of SQLServer');
         }
     }
 


### PR DESCRIPTION
SQL Driver version 5.9 supports version 11+. SQL server 2012 is version 11 https://docs.microsoft.com/en-us/sql/connect/php/microsoft-php-drivers-for-sql-server-support-matrix?view=sql-server-ver15