### PR TITLE
Fixed PHP 8.1 compatibility

### DIFF
--- a/src/Driver/SQLite/Schema/SQLiteForeignKey.php
+++ b/src/Driver/SQLite/Schema/SQLiteForeignKey.php
@@ -68,7 +68,7 @@ class SQLiteForeignKey extends AbstractForeignKey
      */
     public static function createInstance(string $table, string $tablePrefix, array $schema): self
     {
-        $reference = new self($table, $tablePrefix, $schema['id']);
+        $reference = new self($table, $tablePrefix, (string) $schema['id']);
 
         $reference->columns = $schema['from'];
         $reference->foreignTable = $schema['table'];


### PR DESCRIPTION
```
[TypeError]                                                                                                                                                                                                                                                                 
 Spiral\Database\Schema\AbstractForeignKey::__construct(): Argument #3 ($name) must be of type string, int given, called in /Users/roquie/google_drive/projects/backend/vendor/spiral/database/src/Driver/SQLite/Schema/SQLiteForeignKey.php on line 71 
```