### PR TITLE
Map `mysqlnd` `Packets out of order` error as ConnectionException

### DIFF
--- a/src/Driver/MySQL/MySQLDriver.php
+++ b/src/Driver/MySQL/MySQLDriver.php
@@ -67,6 +67,7 @@ class MySQLDriver extends Driver
             strpos($message, 'server has gone away') !== false
             || strpos($message, 'broken pipe') !== false
             || strpos($message, 'connection') !== false
+            || strpos($message, 'packets out of order') !== false
             || ((int)$exception->getCode() > 2000 && (int)$exception->getCode() < 2100)
         ) {
             return new StatementException\ConnectionException($exception, $query);

--- a/tests/Database/Driver/MySQL/ExceptionsTest.php
+++ b/tests/Database/Driver/MySQL/ExceptionsTest.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\Database\Tests\Driver\MySQL;
 
+use Spiral\Database\Exception\StatementException\ConnectionException;
+
 /**
  * @group driver
  * @group driver-mysql
@@ -18,4 +20,29 @@ namespace Spiral\Database\Tests\Driver\MySQL;
 class ExceptionsTest extends \Spiral\Database\Tests\ExceptionsTest
 {
     public const DRIVER = 'mysql';
+
+    protected function getConnectionId(): int
+    {
+        return (int) $this->database->query("SELECT CONNECTION_ID() AS id;")->fetchAll()[0]['id'] ?? 0;
+    }
+
+    public function testPacketsOutOfOrderConsideredAsConnectionException(): void
+    {
+        $connectionId = $this->getConnectionId();
+
+        // Prepare connection to generate "Packets out of order. Expected 1 received 0. Packet size=145"
+        // at the next query response
+        $this->database->query("SET SESSION wait_timeout=1")->fetch();
+        sleep(1);
+
+        try {
+            $newConnectionId = $this->getConnectionId();
+            $this->assertNotEquals(0, $newConnectionId);
+        } catch (\RuntimeException $e) {
+            $this->assertInstanceOf(ConnectionException::class, $e);
+            return;
+        }
+
+        $this->assertNotSame($connectionId, $newConnectionId, 'Expected reconnect for database connection');
+    }
 }


### PR DESCRIPTION
Map `mysqlnd` `Packets out of order` error as ConnectionException for MySQL driver.

Close #82 