### PR TITLE
Fix interpolator

### DIFF
--- a/src/Query/Interpolator.php
+++ b/src/Query/Interpolator.php
@@ -23,9 +23,9 @@ final class Interpolator
     /**
      * Injects parameters into statement. For debug purposes only.
      *
-     * @param string   $query
-     * @param iterable $parameters
-     * @return string
+     * @psalm-param non-empty-string $query
+     *
+     * @psalm-return non-empty-string
      */
     public static function interpolate(string $query, iterable $parameters = []): string
     {
@@ -33,58 +33,58 @@ final class Interpolator
             return $query;
         }
 
-        //Let's prepare values so they looks better
-        foreach ($parameters as $index => $parameter) {
-            if (!is_numeric($index)) {
-                $query = str_replace(
-                    [':' . $index, $index],
-                    self::resolveValue($parameter),
-                    $query
-                );
-                continue;
+        ['named' => $named, 'unnamed' => $unnamed] = self::normalizeParameters($parameters);
+        $params = self::findParams($query);
+
+        $caret = 0;
+        $result = '';
+        foreach ($params as $pos => $ph) {
+            $result .= \substr($query, $caret, $pos - $caret);
+            $caret = $pos + \strlen($ph);
+            // find param
+            if ($ph === '?' && \count($unnamed) > 0) {
+                $result .= self::resolveValue(\array_shift($unnamed));
+            } elseif (\array_key_exists($ph, $named)) {
+                $result .= self::resolveValue($named[$ph]);
+            } else {
+                $result .= $ph;
             }
-
-            $query = self::replaceOnce(
-                '?',
-                self::resolveValue($parameter),
-                $query
-            );
         }
+        $result .= \substr($query, $caret);
 
-        return $query;
+        return $result;
     }
 
     /**
      * Get parameter value.
      *
-     * @param mixed $parameter
-     * @return string
+     * @psalm-return non-empty-string
      */
-    protected static function resolveValue($parameter): string
+    private static function resolveValue($parameter): string
     {
         if ($parameter instanceof ParameterInterface) {
             return self::resolveValue($parameter->getValue());
         }
 
-        switch (gettype($parameter)) {
+        switch (\gettype($parameter)) {
             case 'boolean':
                 return $parameter ? 'TRUE' : 'FALSE';
 
             case 'integer':
-                return (string)($parameter + 0);
+                return (string)$parameter;
 
             case 'NULL':
                 return 'NULL';
 
             case 'double':
-                return sprintf('%F', $parameter);
+                return \sprintf('%F', $parameter);
 
             case 'string':
-                return "'" . addcslashes($parameter, "'") . "'";
+                return "'" . self::escapeStringValue($parameter) . "'";
 
             case 'object':
                 if (method_exists($parameter, '__toString')) {
-                    return "'" . addcslashes((string)$parameter, "'") . "'";
+                    return "'" . self::escapeStringValue((string)$parameter) . "'";
                 }
 
                 if ($parameter instanceof DateTimeInterface) {
@@ -95,26 +95,59 @@ final class Interpolator
         return '[UNRESOLVED]';
     }
 
+    private static function escapeStringValue(string $value): string
+    {
+        return \strtr($value, [
+            '\\%'    => '\\%',
+            '\\_'    => '\\_',
+            \chr(26) => '\\Z',
+            \chr(0)  => '\\0',
+            "'"      => "\\'",
+            \chr(8)  => '\\b',
+            "\n"     => '\\n',
+            "\r"     => '\\r',
+            "\t"     => '\\t',
+            '\\'     => '\\\\',
+        ]);
+    }
+
     /**
-     * Replace search value only once.
-     *
-     * @see http://stackoverflow.com/questions/1252693/using-str-replace-so-that-it-only-acts-on-the-first-match
-     *
-     * @param string $search
-     * @param string $replace
-     * @param string $subject
-     * @return string
+     * @return array<int, string>
      */
-    private static function replaceOnce(
-        string $search,
-        string $replace,
-        string $subject
-    ): string {
-        $position = strpos($subject, $search);
-        if ($position !== false) {
-            return substr_replace($subject, $replace, $position, strlen($search));
+    private static function findParams(string $query): array
+    {
+        \preg_match_all(
+            '/(?<dq>"(?:\\\\\"|[^"])*")|(?<sq>\'(?:\\\\\'|[^\'])*\')|(?<ph>\\?)|(?<named>:[a-z_\\d]+)/',
+            $query,
+            $placeholders,
+            PREG_OFFSET_CAPTURE | PREG_UNMATCHED_AS_NULL
+        );
+        $result = [];
+        foreach (array_merge($placeholders['named'], $placeholders['ph']) as $tuple) {
+            if ($tuple[0] === null) {
+                continue;
+            }
+            $result[$tuple[1]] = $tuple[0];
+        }
+        \ksort($result);
+
+        return $result;
+    }
+
+    /**
+     * @return array{named: array, unnamed: array}
+     */
+    private static function normalizeParameters(iterable $parameters): array
+    {
+        $result = ['named' => [], 'unnamed' => []];
+        foreach ($parameters as $k => $v) {
+            if (\is_int($k)) {
+                $result['unnamed'][$k] = $v;
+            } else {
+                $result['named'][':' . \ltrim($k, ':')] = $v;
+            }
         }
 
-        return $subject;
+        return $result;
     }
 }

--- a/tests/Database/InterpolatorTest.php
+++ b/tests/Database/InterpolatorTest.php
@@ -14,25 +14,27 @@ namespace Spiral\Database\Tests;
 use PHPUnit\Framework\TestCase;
 use Spiral\Database\Injection\Parameter;
 use Spiral\Database\Query\Interpolator;
+use stdClass;
 
 class InterpolatorTest extends TestCase
 {
     public function testInterpolation(): void
     {
-        $query = 'SELECT * FROM table WHERE name = ? AND id IN(?, ?, ?) AND balance > ?';
+        $query = 'SELECT * FROM table WHERE name = ? AND last_name = ? AND id IN(?, ?, ?) AND balance > ?';
 
         $parameters = [
-            new Parameter('Anton'),
+            new Parameter('Anton?'),
             1,
             2,
             3,
             new Parameter(120),
+            '?',
         ];
 
         $interpolated = Interpolator::interpolate($query, $parameters);
 
         $this->assertSame(
-            'SELECT * FROM table WHERE name = \'Anton\' AND id IN(1, 2, 3) AND balance > 120',
+            "SELECT * FROM table WHERE name = 'Anton?' AND last_name = '?' AND id IN(1, 2, 3) AND balance > 120",
             $interpolated
         );
     }
@@ -42,7 +44,7 @@ class InterpolatorTest extends TestCase
         $query = 'SELECT * FROM table WHERE name = :name AND registered > :registered';
 
         $parameters = [
-            ':name'       => new Parameter('Anton'),
+            ':name' => new Parameter('Anton'),
             ':registered' => new Parameter($date = new \DateTime('now')),
         ];
 
@@ -60,7 +62,7 @@ class InterpolatorTest extends TestCase
         $query = 'SELECT * FROM table WHERE name = :name AND registered > :registered';
 
         $parameters = [
-            ':name'       => new Parameter('Anton'),
+            ':name' => new Parameter('Anton'),
             ':registered' => new Parameter($date = new \DateTimeImmutable('now')),
         ];
 
@@ -70,6 +72,210 @@ class InterpolatorTest extends TestCase
             'SELECT * FROM table WHERE name = \'Anton\' AND registered > \''
             . $date->format(\DateTime::ATOM)
             . '\'',
+            $interpolated
+        );
+    }
+
+    public function testInterpolationUseNamedParameterTwice(): void
+    {
+        $query = 'SELECT :name as prefix, name FROM table WHERE name LIKE (CONCAT(:name, "%"))';
+
+        $parameters = [
+            ':name' => 'John',
+        ];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            "SELECT 'John' as prefix, name FROM table WHERE name LIKE (CONCAT('John', \"%\"))",
+            $interpolated
+        );
+    }
+
+    public function testInterpolateNamedParametersWhenFirstIsPrefixOfSecond(): void
+    {
+        $query = 'SELECT * FROM table WHERE parameter = :parameter AND param = :param';
+
+        $parameters = [
+            'param' => 'foo',
+            'parameter' => 'bar',
+        ];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            "SELECT * FROM table WHERE parameter = 'bar' AND param = 'foo'",
+            $interpolated
+        );
+    }
+
+    public function testInterpolateParametersInStrings(): void
+    {
+        $query = 'SELECT \'?\', \'?\\\'?\', "?\\"?" as qq FROM table ' .
+            'WHERE parameter = (":param", \':param\\\':param\', :param, ?)';
+
+        $parameters = [
+            'param' => 'foo',
+            42,
+        ];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            'SELECT \'?\', \'?\\\'?\', "?\\"?" as qq FROM table ' .
+            'WHERE parameter = (":param", \':param\\\':param\', \'foo\', 42)',
+            $interpolated
+        );
+    }
+
+    public function testNestedInterpolation(): void
+    {
+        $query = 'SELECT * FROM table WHERE name = ? AND ' .
+            "id IN(\"in dq ?\", 'in \n\n sq ?', ?) AND " .
+            "balance > IN(\"in dq :p\", 'in sq :p', :p)";
+
+        $parameters = [
+            42,
+            'foo',
+            ':p' => 'bar',
+        ];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            'SELECT * FROM table WHERE name = 42 ' .
+            "AND id IN(\"in dq ?\", 'in \n\n sq ?', 'foo') " .
+            "AND balance > IN(\"in dq :p\", 'in sq :p', 'bar')",
+            $interpolated
+        );
+    }
+
+    public function testNamedParameterNotProvided(): void
+    {
+        $query = 'SELECT * FROM table WHERE name = :name';
+
+        $parameters = ['foo'];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            'SELECT * FROM table WHERE name = :name',
+            $interpolated
+        );
+    }
+
+    public function testUnnamedParameterNotProvided(): void
+    {
+        $query = 'SELECT * FROM table WHERE name = ? OR value > ?';
+
+        $parameters = ['foo' => 'bar'];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            'SELECT * FROM table WHERE name = ? OR value > ?',
+            $interpolated
+        );
+    }
+
+    public function testStringableObjectInterpolation(): void
+    {
+        $query = 'SELECT * FROM table WHERE name = :name';
+
+        $parameters = ['name' => new class () {
+            public function __toString(): string
+            {
+                return 'foo';
+            }
+        }];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            "SELECT * FROM table WHERE name = 'foo'",
+            $interpolated
+        );
+    }
+
+    public function testNotStringableObjectInterpolation(): void
+    {
+        $query = 'SELECT * FROM table WHERE name = :name';
+
+        $parameters = ['name' => new stdClass('foo')];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            'SELECT * FROM table WHERE name = [UNRESOLVED]',
+            $interpolated
+        );
+    }
+
+    public function testFloatValueInterpolation(): void
+    {
+        $query = 'SELECT * FROM table WHERE value > :value1 OR value < :value2';
+
+        $parameters = ['value1' => 0.001, 'value2' => 0.0000001];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            'SELECT * FROM table WHERE value > 0.001000 OR value < 0.000000',
+            $interpolated
+        );
+    }
+
+    public function testNullBoolValueInterpolation(): void
+    {
+        $query = 'SELECT * FROM table WHERE value = :value1 OR value = :value2 OR value = ?';
+
+        $parameters = ['value1' => true, 'value2' => false, null];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            'SELECT * FROM table WHERE value = TRUE OR value = FALSE OR value = NULL',
+            $interpolated
+        );
+    }
+
+    public function testNoParametersPassed(): void
+    {
+        $query = 'SELECT * FROM table WHERE name = :name';
+
+        $parameters = [];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            'SELECT * FROM table WHERE name = :name',
+            $interpolated
+        );
+    }
+
+    public function testBackslashEscaping(): void
+    {
+        $query = 'SELECT :c26, :c0, :sq, :dq, :b, :bs, :n, :r, :t, :pc, :us, :pc_esc';
+
+        $parameters = [
+            'c26' => \chr(26),
+            'c0' => \chr(0),
+            'sq' => "'",
+            'dq' => '"',
+            'b' => \chr(8),
+            'bs' => '\\',
+            'n' => "\n",
+            'r' => "\r",
+            't' => "\t",
+            'pc' => '%',
+            'us' => '_',
+            'pc_esc' => '\\%\\_',
+        ];
+
+        $interpolated = Interpolator::interpolate($query, $parameters);
+
+        $this->assertSame(
+            "SELECT '\\Z', '\\0', '\\'', '\"', '\\b', '\\\\', '\\n', '\\r', '\\t', '%', '_', '\\%\\_'",
             $interpolated
         );
     }


### PR DESCRIPTION
Adapted for PHP 7.2 port of this MR https://github.com/cycle/database/pull/60

Replaced:
- `$result .= match (true) {` to `if/else`
- delete `mixed` type hint
- `if ($parameter instanceof Stringable) {` to `if (method_exists($parameter, '__toString')) {`
- `foreach ([...$placeholders['named'], ...$placeholders['ph']] as $tuple) {` to `foreach (array_merge($placeholders['named'], $placeholders['ph']) as $tuple)`